### PR TITLE
 Sync Dockerfile with new ubuntu-python: new 18.04 release and new python 2 version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ ARG CMAKEFLAGS="-DENABLE_UI=OFF -DENABLE_EXPOSE_SUBPACKAGES=ON -DENABLE_ODB=ON -
 ARG DEBIAN_FRONTEND="noninteractive"
 
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
-
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
     bison \
     cmake \
@@ -24,8 +23,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     libfreetype6-dev \
     libfftw3-dev \
     libgdbm-dev \
-    libjasper-dev \
-    libopenjpeg5 \
+    libopenjp2-7-dev \
     libpango1.0-dev \
     libproj-dev \
     libnetcdf-cxx-legacy-dev \
@@ -39,7 +37,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
 COPY $SOURCE /tmp/$SOURCE
 
 RUN cd /tmp \
-    && pyenv local 2.7.14 && pip install numpy jinja2 \
+    && pyenv local 2.7.15 && pip install numpy jinja2 \
     && mkdir /tmp/source \
     && tar -xz -C /tmp/source --strip-components=1 -f /tmp/$SOURCE \
     && mkdir /tmp/build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ARG CMAKEFLAGS="-DENABLE_UI=OFF -DENABLE_EXPOSE_SUBPACKAGES=ON -DENABLE_ODB=ON -
 ARG DEBIAN_FRONTEND="noninteractive"
 
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
     bison \
     cmake \


### PR DESCRIPTION
`make image` fails with current `bopen/ubuntu-pyenv` base image, mainly due to the update to Ubuntu 18.04.